### PR TITLE
Fix CTD with modded animals in breeding farms

### DIFF
--- a/1.6/Source/PawnStorages/PawnStorages/Factory/Building_PSFactory.cs
+++ b/1.6/Source/PawnStorages/PawnStorages/Factory/Building_PSFactory.cs
@@ -21,7 +21,7 @@ public class Building_PSFactory : Building, IStoreSettingsParent, INutritionStor
     public BillStack billStack;
     public StorageSettings allowedNutritionSettings;
 
-    protected Dictionary<ThingDef, bool> allowedThings;
+    protected Dictionary<ThingDef, bool> allowedThings = new Dictionary<ThingDef, bool>();
 
     public Dictionary<ThingDef, bool> AllowedThings => allowedThings;
     public HashSet<ThingDef> AllowedThingDefs => [.. allowedThings.Keys];

--- a/1.6/Source/PawnStorages/PawnStorages/Farm/Building_PSFarm.cs
+++ b/1.6/Source/PawnStorages/PawnStorages/Farm/Building_PSFarm.cs
@@ -18,7 +18,7 @@ public class Building_PSFarm : Building, IStoreSettingsParent, INutritionStorage
     public CompFarmProducer FarmProducer;
     private StorageSettings allowedNutritionSettings;
 
-    protected Dictionary<ThingDef, bool> allowedThings;
+    protected Dictionary<ThingDef, bool> allowedThings = new Dictionary<ThingDef, bool>();
 
     public Dictionary<ThingDef, bool> AllowedThings => allowedThings;
     public HashSet<ThingDef> AllowedThingDefs => [.. allowedThings.Keys];

--- a/1.6/Source/PawnStorages/PawnStorages/Farm/Comps/CompFarmBreeder.cs
+++ b/1.6/Source/PawnStorages/PawnStorages/Farm/Comps/CompFarmBreeder.cs
@@ -120,11 +120,17 @@ namespace PawnStorages.Farm.Comps
                     continue;
                 }
 
+                Dictionary<PawnKindDef, AutoSlaughterCullOrder> cullOrders = GetOrPopulateAutoSlaughterCullOrder();
+                if (!cullOrders.ContainsKey(type.Key))
+                {
+                    cullOrders.Add(type.Key, new AutoSlaughterCullOrder());
+                }
+
                 var groupedByAgeAndGender = type.GroupBy(p => new { p.ageTracker.Adult, p.gender })
                     .Select(group => new
                     {
                         FarmAnimalCharacteristics = new FarmAnimalCharacteristics(group.Key.Adult, group.Key.gender),
-                        Pawns = GetOrPopulateAutoSlaughterCullOrder()[type.Key].IsAscending(group.Key.Adult, group.Key.gender)
+                        Pawns = cullOrders[type.Key].IsAscending(group.Key.Adult, group.Key.gender)
                             ? group.OrderBy(p => p.ageTracker.ageBiologicalTicksInt)
                             : group.OrderByDescending(p => p.ageTracker.ageBiologicalTicksInt),
                     })


### PR DESCRIPTION
## Summary
Fixes #87

- Initialize `allowedThings` dictionary at field declaration in `Building_PSFarm` and `Building_PSFactory` to prevent `NullReferenceException` during save loading (before `SpawnSetup` runs)
- Add safe dictionary access in `CompFarmBreeder.TryCull()` for modded animal `PawnKindDef`s not present in `AllAnimalKinds` — prevents `KeyNotFoundException` with mods like Alpha Animals

## Test plan
- [ ] Load a save with breeding farms containing modded animals (e.g., Alpha Animals thunderox)
- [ ] Verify no CTD after ~1 minute of gameplay
- [ ] Verify auto-slaughter settings work correctly for both vanilla and modded animals

🤖 Generated with [Claude Code](https://claude.com/claude-code)