### PR TITLE
Designator cleanup: research gate and farm tab

### DIFF
--- a/1.6/Defs/Buildings/Buildings_Production.xml
+++ b/1.6/Defs/Buildings/Buildings_Production.xml
@@ -149,6 +149,9 @@
         <terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
         <designationCategory>Misc</designationCategory>
         <surfaceType>Item</surfaceType>
+        <researchPrerequisites>
+            <li>PS_Crystallization</li>
+        </researchPrerequisites>
     </ThingDef>
 
 </Defs>

--- a/1.6/Defs/ResearchProjectDefs/ResearchProjects_PS.xml
+++ b/1.6/Defs/ResearchProjectDefs/ResearchProjects_PS.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+    <ResearchProjectDef>
+        <defName>PS_Crystallization</defName>
+        <label>crystallization</label>
+        <description>Learn how to crystallize living beings into a suspended state within specially grown crystals.</description>
+        <baseCost>300</baseCost>
+        <techLevel>Industrial</techLevel>
+        <tab>Main</tab>
+        <researchViewX>7</researchViewX>
+        <researchViewY>4</researchViewY>
+    </ResearchProjectDef>
+</Defs>

--- a/1.6/Patches/FarmDesignationCategoryPatch.xml
+++ b/1.6/Patches/FarmDesignationCategoryPatch.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Fertile Fields</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <success>Always</success>
+            <operations>
+                <li Class="PatchOperationReplace">
+                    <success>Always</success>
+                    <xpath>Defs/ThingDef[defName="PS_BatteryFarm"]/designationCategory</xpath>
+                    <value><designationCategory>Farming</designationCategory></value>
+                </li>
+                <li Class="PatchOperationReplace">
+                    <success>Always</success>
+                    <xpath>Defs/ThingDef[defName="PS_BreedingFarm"]/designationCategory</xpath>
+                    <value><designationCategory>Farming</designationCategory></value>
+                </li>
+                <li Class="PatchOperationReplace">
+                    <success>Always</success>
+                    <xpath>Defs/ThingDef[defName="PS_RusticFarm"]/designationCategory</xpath>
+                    <value><designationCategory>Farming</designationCategory></value>
+                </li>
+                <li Class="PatchOperationReplace">
+                    <success>Always</success>
+                    <xpath>Defs/ThingDef[defName="PS_BreedingFarmRustic"]/designationCategory</xpath>
+                    <value><designationCategory>Farming</designationCategory></value>
+                </li>
+                <li Class="PatchOperationReplace">
+                    <success>Always</success>
+                    <xpath>Defs/ThingDef[defName="PS_FarmHopper"]/designationCategory</xpath>
+                    <value><designationCategory>Farming</designationCategory></value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+</Patch>


### PR DESCRIPTION
## Summary
Addresses #61

- Add `PS_Crystallization` research project (Industrial, 300 cost) to gate the Crystallizer building behind research
- Add Fertile Fields compatibility patch that moves farm buildings to the Farming designation category when that mod is active
- Hopper and farm dropdowns were already correctly organized (no changes needed)

## Test plan
- [ ] Verify Crystallizer is unavailable until PS_Crystallization is researched
- [ ] With Fertile Fields loaded, verify farm buildings appear in Farming tab instead of Production
- [ ] Without Fertile Fields, verify farm buildings remain in Production tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)