### PR TITLE
Capture spheres tame animals and enslave humanoids

### DIFF
--- a/1.6/Source/PawnStorages/PawnStorages/CaptureSphere/Projectile_Capturing.cs
+++ b/1.6/Source/PawnStorages/PawnStorages/CaptureSphere/Projectile_Capturing.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using RimWorld;
 using UnityEngine;
 using Verse;
 using Verse.Sound;
@@ -222,9 +223,45 @@ public class Projectile_Capturing : Projectile
 
             Hediff hediff = pawn.health.GetOrAddHediff(PS_DefOf.PS_CapturedPawn);
             hediff.visible = false;
+
+            ApplyPostCaptureEffects(pawn);
         }
 
         return true;
+    }
+
+    private void ApplyPostCaptureEffects(Pawn pawn)
+    {
+        Faction playerFaction = LauncherPawn?.Faction ?? Faction.OfPlayer;
+
+        // Skip if pawn was already in the player's faction
+        if (pawn.Faction == playerFaction)
+            return;
+
+        if (pawn.RaceProps.Animal)
+        {
+            // SetFaction automatically handles tameness training for animals
+            pawn.SetFaction(playerFaction, LauncherPawn);
+            Messages.Message(
+                "PS_AnimalCapturedTamed".Translate(pawn.LabelShortCap),
+                pawn,
+                MessageTypeDefOf.PositiveEvent,
+                false
+            );
+        }
+        else if (pawn.RaceProps.Humanlike)
+        {
+            if (pawn.guest != null && ModsConfig.IdeologyActive)
+            {
+                pawn.guest.SetGuestStatus(playerFaction, GuestStatus.Slave);
+                Messages.Message(
+                    "PS_PawnCapturedEnslaved".Translate(pawn.LabelShortCap),
+                    pawn,
+                    MessageTypeDefOf.NeutralEvent,
+                    false
+                );
+            }
+        }
     }
 
     public bool Capture()

--- a/Common/Languages/English/Keyed/Misc_Gameplay.xml
+++ b/Common/Languages/English/Keyed/Misc_Gameplay.xml
@@ -136,4 +136,7 @@
     <PS_BillLimitReached>Bill limit reached (maximum 15 bills per factory).</PS_BillLimitReached>
     <PS_AddBill_NoResults>(no matching recipes)</PS_AddBill_NoResults>
     <PS_AddBill_BillCount>{0} bills queued</PS_AddBill_BillCount>
+
+    <PS_AnimalCapturedTamed>{0} has been captured and tamed!</PS_AnimalCapturedTamed>
+    <PS_PawnCapturedEnslaved>{0} has been captured and enslaved!</PS_PawnCapturedEnslaved>
 </LanguageData>


### PR DESCRIPTION
## Summary
Fixes #40

- Add `ApplyPostCaptureEffects()` to `Projectile_Capturing`, called after pawn is stored in `TryAddToNewBall()`
- Animals: `SetFaction(playerFaction)` — vanilla automatically handles tameness training
- Humanoids: `SetGuestStatus(playerFaction, GuestStatus.Slave)` when Ideology DLC is active
- Shows appropriate messages ("captured and tamed!" / "captured and enslaved!")
- Same-faction pawns are unaffected (no-op guard)

## Test plan
- [ ] Capture a wild animal — verify it becomes tamed on release
- [ ] Capture a hostile humanoid — verify they become a slave (with Ideology) or prisoner (without)
- [ ] Capture a same-faction colonist — verify no status change
- [ ] Verify "Return to Sphere" ability still works for tamed/enslaved pawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)