### PR TITLE
Support connected storage for farm/factory inputs

### DIFF
--- a/1.6/Source/PawnStorages/PawnStorages/CompPawnStorageNutrition.cs
+++ b/1.6/Source/PawnStorages/PawnStorages/CompPawnStorageNutrition.cs
@@ -374,6 +374,12 @@ public class CompPawnStorageNutrition : ThingComp
                 return feedInAnyHopper;
         }
 
+        // Fallback: check connected storage buildings (shelves, stockpiles, fridges)
+        List<Thing> connectedFeed = Utility.FindThingsInConnectedStorage(parent,
+            thing => ValidFeedstock(thing.def));
+        if (connectedFeed.Count > 0)
+            return connectedFeed[0];
+
         return null;
     }
 
@@ -408,7 +414,15 @@ public class CompPawnStorageNutrition : ThingComp
                 return true;
         }
 
-        return false;
+        // Also check connected storage
+        List<Thing> connectedFeed = Utility.FindThingsInConnectedStorage(parent,
+            thing => IsAcceptableFeedstock(thing.def));
+        for (int i = 0; i < connectedFeed.Count; i++)
+        {
+            num += connectedFeed[i].GetStatValue(StatDefOf.Nutrition) * (float)connectedFeed[i].stackCount;
+        }
+
+        return num > 0;
     }
 
     public override IEnumerable<Gizmo> CompGetGizmosExtra()

--- a/1.6/Source/PawnStorages/PawnStorages/Factory/CompFactoryProducer.cs
+++ b/1.6/Source/PawnStorages/PawnStorages/Factory/CompFactoryProducer.cs
@@ -135,6 +135,36 @@ public class CompFactoryProducer : CompPawnStorageProducer
             }
         }
 
+        // Fallback: check connected storage if not all ingredients found
+        if (done.Any(pair => !pair.Value))
+        {
+            HashSet<SlotGroup> slotGroups = Utility.FindConnectedSlotGroups(parent);
+            foreach (SlotGroup slotGroup in slotGroups)
+            {
+                foreach (Thing thing in slotGroup.HeldThings)
+                {
+                    foreach (IngredientCount ingredientCount in ingredientList)
+                    {
+                        if (done[ingredientCount] || !ingredientCount.filter.Allows(thing))
+                            continue;
+                        int countSoFarForIngredient = countSoFar.GetWithFallback(ingredientCount, 0);
+                        int required = ingredientCount.CountRequiredOfFor(thing.def, bill.recipe);
+                        required -= countSoFarForIngredient;
+                        if (required > 0)
+                        {
+                            int reservedSoFar = reserved.GetWithFallback(thing, 0);
+                            int reservable = thing.stackCount - reservedSoFar;
+                            int toReserve = Math.Min(required, reservable);
+                            if (toReserve >= required)
+                                done[ingredientCount] = true;
+                            reserved.SetOrAdd(thing, toReserve + reservedSoFar);
+                            countSoFar.SetOrAdd(ingredientCount, countSoFarForIngredient + toReserve);
+                        }
+                    }
+                }
+            }
+        }
+
         return done.Any(pair => !pair.Value) ? [] : reserved;
     }
 

--- a/1.6/Source/PawnStorages/PawnStorages/Utility.cs
+++ b/1.6/Source/PawnStorages/PawnStorages/Utility.cs
@@ -186,4 +186,42 @@ public static class Utility
 
         return animals ??= AllAnimalKinds.Value.Select(k => k.race).ToList();
     }
+
+    public static HashSet<SlotGroup> FindConnectedSlotGroups(Thing parent)
+    {
+        HashSet<SlotGroup> slotGroups = new HashSet<SlotGroup>();
+        if (!parent.Spawned || parent.Map == null)
+            return slotGroups;
+
+        foreach (IntVec3 cell in GenAdj.CellsAdjacentCardinal(parent))
+        {
+            if (!cell.InBounds(parent.Map))
+                continue;
+
+            SlotGroup slotGroup = parent.Map.haulDestinationManager.SlotGroupAt(cell);
+            if (slotGroup != null)
+            {
+                slotGroups.Add(slotGroup);
+            }
+        }
+        return slotGroups;
+    }
+
+    public static List<Thing> FindThingsInConnectedStorage(Thing parent, System.Predicate<Thing> validator)
+    {
+        List<Thing> result = new List<Thing>();
+        HashSet<SlotGroup> slotGroups = FindConnectedSlotGroups(parent);
+
+        foreach (SlotGroup slotGroup in slotGroups)
+        {
+            foreach (Thing thing in slotGroup.HeldThings)
+            {
+                if (validator(thing))
+                {
+                    result.Add(thing);
+                }
+            }
+        }
+        return result;
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #60

- Add `Utility.FindConnectedSlotGroups()` and `Utility.FindThingsInConnectedStorage()` helper methods that scan cardinally adjacent cells for `SlotGroup` instances (shelves, stockpile zones, fridges, modded storage)
- Extend `CompPawnStorageNutrition.FindFeedInAnyHopper()` — falls back to connected storage when no hopper feed found
- Extend `CompPawnStorageNutrition.HasEnoughFeedstockInHoppers()` — includes connected storage nutrition in total
- Extend `CompFactoryProducer.SelectedIngredientsFor()` — scans connected storage for unsatisfied recipe ingredients
- Hoppers still take priority (connected storage is a fallback), preserving backward compatibility
- Automatically works with any mod that uses `ISlotGroupParent` (RimFridge, Project RimFactory, etc.)

## Test plan
- [ ] Place a shelf adjacent to a farm — verify it pulls nutrition from the shelf
- [ ] Place a stockpile zone adjacent to a factory — verify it finds ingredients
- [ ] Verify hoppers still work and are checked first
- [ ] Test with modded storage (RimFridge, deep storage) if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)